### PR TITLE
Support nested Astro code blocks in Markdown

### DIFF
--- a/packages/vscode/syntaxes/astro.inject-to-markdown.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.inject-to-markdown.tmLanguage.json
@@ -42,7 +42,7 @@
 									"include": "#frontmatter"
 								},
 								{
-									"begin": "^(?=\\S)|(?!\\G)",
+									"begin": "(?<=^\\s*)(?=\\S)|(?!\\G)",
 									"end": "(?<=\\s*([`~]{3,})\\s*$)(^|\\G)",
 									"patterns": [
 										{
@@ -57,13 +57,13 @@
 			]
 		},
 		"frontmatter": {
-			"begin": "^-{3}\\s*$",
+			"begin": "(^\\s*|(?<=\\s*))-{3}\\s*$",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.tag.xi.begin.t"
 				}
 			},
-			"end": "^-{3}\\s*$",
+			"end": "(^\\s*|(?<=\\s*))-{3}\\s*$",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.definition.tag.xi.end.t"


### PR DESCRIPTION
## Changes

- Supports nested Astro code blocks

`````markdown
An Astro code block.

```astro
---
import Whatever from './whatever.astro'
---
<Whatever joy="lol">
  <div></div>
</Whatever>
```

- A nested Astro code block.
  ```astro
  ---
  import Whatever from './whatever.astro'
  ---
  <Whatever joy="lol">
    <div></div>
  </Whatever>
  ```
  - A deeply nested Astro code block.
    ```astro
    ---
    import Whatever from './whatever.astro'
    ---
    <Whatever joy="lol">
      <div></div>
    </Whatever>
    ```

An indented Astro code block.

  ```astro
  ---
  import Whatever from './whatever.astro'
  ---
  <Whatever joy="lol">
    <div></div>
  </Whatever>
  ```
`````

## Testing

The above markdown in its own file.

## Docs

bug fix only