### PR TITLE
Support template literal attribute values (for syntax highlighting)

### DIFF
--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -615,6 +615,16 @@
         }
       ]
     },
+    "string-template-literal": {
+      "begin": "`",
+      "end": "`",
+      "name": "string.quoted.single.html",
+      "patterns": [
+        {
+          "include": "source.tsx#template-substitution-element"
+        }
+      ]
+    },
     "tag-generic-attribute": {
       "match": "(@|\\b)([a-zA-Z\\-:]+)",
       "name": "entity.other.attribute-name.html"
@@ -695,6 +705,9 @@
         },
         {
           "include": "#string-single-quoted"
+        },
+        {
+          "include": "#string-template-literal"
         },
         {
           "include": "#astro-load-directive"


### PR DESCRIPTION
## Changes

- Adds support for template literal attribute values (only for syntax highlighting).

```astro
---
import Whatever from './whatever.astro'

const lol = 'awesome'
---
<Whatever one={`lol${lol}`} two=`lol${lol}`>
  <div></div>
</Whatever>
```


## Testing

The above astro in its own file.

## Docs

bug fix only