### PR TITLE
Upgrade TypeScript from 4.5.1-rc to 4.5.2 (stable)

### DIFF
--- a/.changeset/fast-socks-smoke.md
+++ b/.changeset/fast-socks-smoke.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Updates `typescript` from 4.5.1-rc to 4.5.2 (stable)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.2.1",
     "svelte": "^3.38.0",
     "tiny-glob": "^0.2.8",
-    "typescript": "^4.5.1-rc",
+    "typescript": "^4.5.2",
     "uvu": "^0.5.1"
   },
   "engines": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",
     "ts-morph": "^12.0.0",
-    "typescript": "^4.5.1-rc",
+    "typescript": "^4.5.2",
     "vscode-css-languageservice": "^5.1.1",
     "vscode-emmet-helper": "2.1.2",
     "vscode-html-languageservice": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9245,15 +9245,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
-  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
-
-typescript@^4.5.1-rc:
-  version "4.5.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.1-rc.tgz#02155eaa0579d11babb2a55dcbd796948a994bb3"
-  integrity sha512-tQBWW1DCFqweyhSzsAUSFgssJ3uuRBh0zyOkRV4CaFF2rMBkGU0I+MqPMch0qhGCUGXjOW7FgMrbQLS6PE3Z6Q==
+typescript@4.5.2, typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
## Changes

- Updates `typescript` from 4.5.1-rc to 4.5.2 (stable)

## Testing

dependency update only

## Docs

dependency update only