### PR TITLE
fix: ignore tsconfig setting files

### DIFF
--- a/.changeset/grumpy-experts-rest.md
+++ b/.changeset/grumpy-experts-rest.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Prevent reading tsconfig in .astro files

--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -55,18 +55,7 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
     },
   };
 
-  let configJson = (tsconfigPath && ts.readConfigFile(tsconfigPath, ts.sys.readFile).config) || getDefaultJsConfig();
-  if (!configJson.extends) {
-    configJson = Object.assign(
-      {
-        exclude: getDefaultExclude(),
-      },
-      configJson
-    );
-  }
-
-  // Delete include so that astro files don't get excluded.
-  delete configJson.include;
+  const configJson = getDefaultJsConfig();
 
   const existingCompilerOptions: ts.CompilerOptions = {
     jsx: ts.JsxEmit.Preserve,
@@ -174,22 +163,19 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
   }
 }
 
-/**
- * This should only be used when there's no jsconfig/tsconfig at all
- */
 function getDefaultJsConfig(): {
-  compilerOptions: ts.CompilerOptions;
-  include: string[];
+   compilerOptions: ts.CompilerOptions;
+   exclude: string[];
 } {
-  let compilerOptions = {
-    maxNodeModuleJsDepth: 2,
-    allowSyntheticDefaultImports: true,
-    allowJs: true
-  };
-  return {
-    compilerOptions,
-    include: ['src'],
-  };
+   let compilerOptions = {
+      maxNodeModuleJsDepth: 2,
+      allowSyntheticDefaultImports: true,
+      allowJs: true,
+   };
+   return {
+      compilerOptions,
+      exclude: getDefaultExclude(),
+   };
 }
 
 function getDefaultExclude() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9245,7 +9245,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.5.2, typescript@^4.5.2:
+typescript@*:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
+typescript@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
   integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==


### PR DESCRIPTION
Astro should not be reading the tsconf settings file.  This causes issues  such as `strict: true` causing ts errors like:

`JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.`

RE: https://discord.com/channels/830184174198718474/845451724738265138/895704312544653353

Closes #91.

Personal References:
- Link #T-366
- Closes #T-366
