### PR TITLE
Remove import.meta declarations from our d.ts

### DIFF
--- a/.changeset/breezy-stingrays-sing.md
+++ b/.changeset/breezy-stingrays-sing.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Removes errors with import.meta.hot

--- a/packages/language-server/astro.d.ts
+++ b/packages/language-server/astro.d.ts
@@ -1,15 +1,5 @@
 export {};
 
-declare global {
-  interface ImportMeta {
-      hot: {
-          accept: Function;
-          dispose: Function;
-      };
-      env: Record<string, string>;
-  }
-}
-
 type AstroRenderedHTML = string;
 
 type AstroElement = any;


### PR DESCRIPTION
## Changes

- Removes declarations overriding `import.meta.hot` and `import.meta.env` because these declarations are already provided by Vite.
- This removes errors that you see in the Astro repo.

## Testing

Not testable.

## Docs

N/A