### PR TITLE
Update project from astro-language-tools to language-tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snowpackjs/maintainers
+* @withastro/maintainers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: 'A new release of the Astro VSCode extension just went out! [Release notes →](<https://github.com/withastro/astro-language-tools/releases/>)'
+          args: 'A new release of the Astro VSCode extension just went out! [Release notes →](<https://github.com/withastro/language-tools/releases/>)'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/snowpackjs/astro-language-tools.git"
+    "url": "https://github.com/withastro/language-tools.git"
   },
   "scripts": {
     "release": "yarn build && changeset publish",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -44,8 +44,8 @@
   ],
   "repository": {
     "type": "git",
-    "directory": "vscode",
-    "url": "https://github.com/snowpackjs/astro"
+    "url": "https://github.com/withastro/language-tools.git",
+    "directory": "packages/vscode"
   },
   "contributes": {
     "typescriptServerPlugins": [


### PR DESCRIPTION
## Changes

- Updates any relevant assets to point to https://github.com/withastro/language-tools
- Conforms `language-tools` with `compiler` (previously `astro-compiler`).

## Testing

name update only

## Docs

name update only